### PR TITLE
Removing Column::TYPE_DECIMAL from noSizeColumnType

### DIFF
--- a/src/Migration/Action/Generate.php
+++ b/src/Migration/Action/Generate.php
@@ -89,7 +89,6 @@ class Generate
 
         Column::TYPE_FLOAT,
         Column::TYPE_DOUBLE,
-        Column::TYPE_DECIMAL,
 
         Column::TYPE_TINYTEXT,
         Column::TYPE_TEXT,

--- a/tests/mysql/ColumnTypesCest.php
+++ b/tests/mysql/ColumnTypesCest.php
@@ -89,6 +89,16 @@ final class ColumnTypesCest
                     'notNull' => true,
                 ],
                 ['Y', 'N', 'D', ''],
+            ],
+            [
+                'column_decimal',
+                [
+                    'type' => Column::TYPE_DECIMAL,
+                    'size' => 10,
+                    'scale' => 2,
+                    'notNull' => true,
+                ],
+                [0, 1, 2.3, 4.56, 12345678.12],
             ]
         ];
     }


### PR DESCRIPTION
According to my test using MySQL / MariaDB, "float" type and "double" type could handle the scale property without the size.
On the other hand, "decimal" type and "numeric" type doesn't seem to handle the scale without any size provided.

```
DECIMAL(0,2) NOT NULL AFTER chargeERROR: SQLSTATE[42000]: Syntax error or access violation: 1427 For float(M,D), double(M,D) or decimal(M,D), M must be >= D (column 'amount')
Obviously because it's "0" instead of "10"
```