### PR TITLE
addslashes only apply to string

### DIFF
--- a/src/Mvc/Model/Migration.php
+++ b/src/Mvc/Model/Migration.php
@@ -302,7 +302,11 @@ class Migration
                             $data[] = $value;
                         }
                     } else {
-                        $data[] = $value === null ? 'NULL' : addslashes($value);
+                        if (is_string($value)) {
+                            $data[] = addslashes($value);
+                        } else {
+                            $data[] = $value === null ? 'NULL' : $value;
+                        }
                     }
 
                     unset($value);


### PR DESCRIPTION
The function "addslashes" only works with strings.
Determine the value type before use.