### PR TITLE
generate command now supports Timestamp based versions

### DIFF
--- a/src/Console/Commands/Migration.php
+++ b/src/Console/Commands/Migration.php
@@ -167,6 +167,7 @@ class Migration implements CommandsInterface
                     'migrationsDir'        => $migrationsDir,
                     'version'              => $this->parser->get('version'),
                     'force'                => $this->parser->has('force'),
+                    'tsBased'              => $migrationsTsBased,
                     'noAutoIncrement'      => $noAutoIncrement,
                     'config'               => $config,
                     'descr'                => $descr,

--- a/src/Console/OptionStack.php
+++ b/src/Console/OptionStack.php
@@ -136,11 +136,12 @@ class OptionStack implements ArrayAccess
         /**
          * Use timestamped version if description is provided.
          */
-        if (isset($this->options['descr'])) {
+        if (isset($this->options['descr']) || !empty($this->options['tsBased'] ?? false)) {
             $this->options['version'] = (string) (int) (microtime(true) * pow(10, 6));
             VersionCollection::setType(VersionCollection::TYPE_TIMESTAMPED);
 
-            return VersionCollection::createItem($this->options['version'] . '_' . $this->options['descr']);
+            $versionName = $this->options['version'] . ($this->options['descr'] ? '_' . $this->options['descr'] : '');
+            return VersionCollection::createItem($versionName);
         }
 
         VersionCollection::setType(VersionCollection::TYPE_INCREMENTAL);


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: https://github.com/phalcon/migrations/issues/144

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:
Add support for timestamp versioning when running `phalcon-migrations generate`

Thanks

[:contrib:]: https://github.com/phalcon/migrations/blob/master/CONTRIBUTING.md
