### PR TITLE
Add BIT as a supported column type

### DIFF
--- a/src/Migration/Action/Generate.php
+++ b/src/Migration/Action/Generate.php
@@ -75,6 +75,7 @@ class Generate
         Column::TYPE_DECIMAL   => 'TYPE_DECIMAL',
 
         Column::TYPE_BOOLEAN  => 'TYPE_BOOLEAN',
+        Column::TYPE_BIT      => 'TYPE_BIT',
         Column::TYPE_FLOAT    => 'TYPE_FLOAT',
         Column::TYPE_DOUBLE   => 'TYPE_DOUBLE',
         Column::TYPE_TINYBLOB => 'TYPE_TINYBLOB',


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: https://github.com/phalcon/migrations/issues/146

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:

Added support for the Bit-Value column type from MySQL 8.

Thanks

[:contrib:]: https://github.com/phalcon/migrations/blob/master/CONTRIBUTING.md
