### PR TITLE
Fix php fatal error for not initialized property

### DIFF
--- a/src/Version/IncrementalItem.php
+++ b/src/Version/IncrementalItem.php
@@ -37,7 +37,7 @@ class IncrementalItem implements ItemInterface
     /**
      * @var string
      */
-    private string $path;
+    private string $path = '';
 
     /**
      * @var string


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/migrations/issues/149

**In raising this pull request, I confirm the following (please check boxes):**

Just run "php vendor/bin/phalcon-migrations run"

- [x ] I have read and understood the [Contributing Guidelines][:contrib:]
- [ x] I have checked that another pull request for this purpose does not exist
- [ x] I wrote some tests for this PR

Small description of change:

Thanks

[:contrib:]: https://github.com/phalcon/migrations/blob/master/CONTRIBUTING.md
